### PR TITLE
feat: configurable subnet IP CIDR range

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,12 @@ variable "use_cloud_nat" {
   default     = false
 }
 
+variable "subnet_ip_cidr_range" {
+  type        = string
+  description = "CIDR range to assign to subnet VM instances launch in."
+  default     = "10.0.1.0/24"
+}
+
 variable "enable_debug" {
   type        = bool
   description = "Enable debug messages of github-runner-autoscaler Cloud Run (WARNING: secrets will be leaked in log files)."

--- a/vpc.tf
+++ b/vpc.tf
@@ -8,7 +8,7 @@ resource "google_compute_network" "vpc_network" {
 resource "google_compute_subnetwork" "subnetwork" {
   name                     = "spot-runner-subnetwork"
   description              = "The subnetwork the ephemeral GitHub runner instances will join"
-  ip_cidr_range            = "10.0.1.0/24"
+  ip_cidr_range            = var.subnet_ip_cidr_range
   network                  = google_compute_network.vpc_network.name
   private_ip_google_access = true
 }


### PR DESCRIPTION
This PR adds the ability to configure the subnet CIDR used for VM instances. We had been seeing instances fail to create with this error:

```
Error #01: googleapi: Error 400: BAD REQUEST: errors:{code:"IP_SPACE_EXHAUSTED_WITH_DETAILS"  message:"IP space of 'projects/$PROJECT/regions/us-central1/subnetworks/spot-runner-subnetwork' is exhausted. Insufficient free IP addresses in the IP range '10.0.1.0/24'. Consider expanding the current IP range or selecting an alternative IP range. If this is a secondary range, consider adding an additional secondary range."}
```

We'd like to just change the subnet to `10.1.0.0/16` (or similar). Rather than change the default, I just made it a variable (with the same default).

I've switched our environment to my fork and it works fine (with a larger subnet):
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/99a4a363-e15a-4db7-aa65-bbff8786c697" />
